### PR TITLE
Fix manifest reference to tesseract wasm

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
 
   "web_accessible_resources": [
     "js/worker.min.js",
-    "js/tessearct-core.wasm.js",
+    "js/tesseract-core.wasm.js",
     "traineddata/*.traineddata.gz"
   ],
 


### PR DESCRIPTION
## Summary
- correct `tesseract-core.wasm.js` filename in `manifest.json`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866e25ba2f0833088101ef718ed006a