### PR TITLE
Add spell correction option

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -87,3 +87,9 @@ body {
 #outputArea {
   padding: 2% 1%;
 }
+
+.spellOption {
+  padding: 1%;
+  font-size: 12px;
+  color: #222222;
+}

--- a/js/popup.js
+++ b/js/popup.js
@@ -2,6 +2,55 @@ document.addEventListener('DOMContentLoaded', function() {
   const state = {
     imgData: null
   };
+
+  const dictionary = [
+    'the','be','to','of','and','a','in','that','have','i','it','for','not','on',
+    'with','he','as','you','do','at','this','but','his','by','from','they','we',
+    'say','her','she','or','an','will','my','one','all','would','there','their',
+    'what','so','up','out','if','about','who','get','which','go','me','when',
+    'make','can','like','time','no','just','him','know','take','people','into',
+    'year','your','good','some','could','them','see','other','than','then',
+    'now','look','only','come','its','over','think','also','back','after','use',
+    'two','how','our','work','first','well','way','even','new','want','because',
+    'any','these','give','day','most','us'
+  ];
+
+  const spellToggle = document.getElementById('spellToggle');
+
+  function levenshtein(a, b) {
+    const dp = Array.from({ length: a.length + 1 }, () => new Array(b.length + 1).fill(0));
+    for (let i = 0; i <= a.length; i++) dp[i][0] = i;
+    for (let j = 0; j <= b.length; j++) dp[0][j] = j;
+    for (let i = 1; i <= a.length; i++) {
+      for (let j = 1; j <= b.length; j++) {
+        const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+        dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost);
+      }
+    }
+    return dp[a.length][b.length];
+  }
+
+  function correctWord(word) {
+    let best = word;
+    let bestDist = 2;
+    const lower = word.toLowerCase();
+    for (const dictWord of dictionary) {
+      const dist = levenshtein(lower, dictWord);
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = dictWord;
+        if (dist === 0) break;
+      }
+    }
+    if (bestDist <= 1 && best !== lower) {
+      return word[0] === word[0].toUpperCase() ? best.charAt(0).toUpperCase() + best.slice(1) : best;
+    }
+    return word;
+  }
+
+  function correctText(text) {
+    return text.split(/\b/).map(token => (/^[A-Za-z]+$/.test(token) ? correctWord(token) : token)).join('');
+  }
   
   const scanArea = document.getElementById('scanArea');
   const outputArea = document.getElementById('outputArea');
@@ -36,7 +85,10 @@ document.addEventListener('DOMContentLoaded', function() {
           worker.recognize(state.imgData)
             .then(({ data }) => {
               const lines = data.lines || [];
-              const segmentedText = lines.map(l => l.text).join('\n');
+              let segmentedText = lines.map(l => l.text).join('\n');
+              if (!spellToggle || spellToggle.checked) {
+                segmentedText = correctText(segmentedText);
+              }
               outputArea.value = segmentedText;
               scanArea.innerText = "Completed!";
             })

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "exprezzo",
+  "version": "1.0.0",
+  "description": "Chrome Extension",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "spellchecker": "^3.7.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/popup.html
+++ b/popup.html
@@ -37,6 +37,9 @@
         <textarea disabled cols="45" rows="10" id="outputArea">Paste an image to start</textarea>
       </div>
     </div>
+    <div class="spellOption">
+      <label><input type="checkbox" id="spellToggle" checked> Enable Spell Correction</label>
+    </div>
   </div>
   <script src="./js/popup.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- use a simple dictionary and Levenshtein distance to correct OCR output
- allow users to enable/disable corrections via checkbox
- style checkbox option and add dependency placeholder

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866f0f6f7d483309dc069c85316c292