### PR TITLE
Fix manifest for V3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,23 +1,25 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
 
   "name": "Exprezzo",
   "description": "This extension converts image to text",
   "version": "1.0",
 
-  "browser_action": {
-   "default_icon": "./assets/icon.png",
-   "default_popup": "popup.html"
+  "action": {
+    "default_icon": "./assets/icon.png",
+    "default_popup": "popup.html"
   },
 
-  "web_accessible_resources": [
-    "js/worker.min.js",
-    "js/tesseract-core.wasm.js",
-    "traineddata/*.traineddata.gz"
-  ],
+  "web_accessible_resources": [{
+    "resources": [
+      "js/worker.min.js",
+      "js/tesseract-core.wasm.js",
+      "traineddata/*.traineddata.gz"
+    ],
+    "matches": ["<all_urls>"]
+  }],
 
   "permissions": [
    "activeTab",
    "tabs"
-   ]
-}
+   ]}


### PR DESCRIPTION
## Summary
- migrate Chrome extension manifest to version 3

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dc2abdd9c8330bae359bbd525e2c3