### PR TITLE
Fix paste handling and add progress indicator

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -60,6 +60,14 @@ body {
   transition: all .2s;
 }
 
+#scanMessage {
+  pointer-events: none;
+}
+
+#scanArea.processing {
+  cursor: progress;
+}
+
 #scanArea:hover {
   transform: scale(1.1);
 }

--- a/js/popup.js
+++ b/js/popup.js
@@ -7,11 +7,14 @@ document.addEventListener('DOMContentLoaded', function() {
   const spellToggle = document.getElementById('spellToggle');
   
   const scanArea = document.getElementById('scanArea');
+  const scanMessage = document.getElementById('scanMessage');
   const outputArea = document.getElementById('outputArea');
   // const img = document.getElementById(imgContainer);
 
-  function handlePaste(e) {
-    scanArea.innerText = "Processing...";
+    function handlePaste(e) {
+      e.preventDefault();
+      scanArea.classList.add('processing');
+      scanMessage.innerText = "Processing...";
 
     const items = (e.clipboardData  || e.originalEvent.clipboardData).items;
 
@@ -42,8 +45,9 @@ document.addEventListener('DOMContentLoaded', function() {
               if (!spellToggle || spellToggle.checked) {
                 segmentedText = correctText(segmentedText);
               }
-              outputArea.value = segmentedText;
-              scanArea.innerText = "Completed!";
+                outputArea.value = segmentedText;
+                scanMessage.innerText = "Completed!";
+                scanArea.classList.remove('processing');
             })
         });
       };
@@ -57,5 +61,4 @@ document.addEventListener('DOMContentLoaded', function() {
   // Allow pasting anywhere in the popup
   document.addEventListener('paste', handlePaste);
 
-  // Focus the editable area by default so Ctrl+V works immediately
-  scanArea.focus();}, false);
+  // Focus the editable area by default so Ctrl+V works immediately  scanArea.focus();}, false);

--- a/popup.html
+++ b/popup.html
@@ -20,11 +20,11 @@
       </span>
     </div>
 
-    <div class="scan">
-      <div id="scanArea" contenteditable="true">
-        Paste Image Here
+      <div class="scan">
+        <div id="scanArea" tabindex="0">
+          <span id="scanMessage">Paste Image Here</span>
+        </div>
       </div>
-    </div>
 
     <!-- <img id="imgContainer" src="" /> -->
 


### PR DESCRIPTION
## Summary
- disable editing in scan area
- prevent default paste behavior
- add processing indicator text and styling
- style scan area while processing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dd0f91d0c8330977eb7b6811da7b3