### PR TITLE
Fix missing closure in popup script

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -60,5 +60,6 @@ document.addEventListener('DOMContentLoaded', function() {
   scanArea.addEventListener('paste', handlePaste);
   // Allow pasting anywhere in the popup
   document.addEventListener('paste', handlePaste);
-
-  // Focus the editable area by default so Ctrl+V works immediately  scanArea.focus();}, false);
+  // Focus the editable area by default so Ctrl+V works immediately
+  scanArea.focus();
+}, false);


### PR DESCRIPTION
## Summary
- close the DOMContentLoaded listener in `popup.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dd6b8f6e08330ac584b129b8b3ec6