### PR TITLE
Handle OCR worker errors gracefully in popup

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -49,6 +49,16 @@ document.addEventListener('DOMContentLoaded', function() {
                 scanMessage.innerText = "Completed!";
                 scanArea.classList.remove('processing');
             })
+            .catch((err) => {
+              console.error(err);
+              scanArea.classList.remove('processing');
+              scanMessage.innerText = 'Failed to process image.';
+              outputArea.value = '';
+              outputArea.setAttribute('disabled', 'true');
+              if (worker.terminate) {
+                worker.terminate();
+              }
+            });
         });
       };
       reader.readAsDataURL(imgBlob);


### PR DESCRIPTION
## Summary
- Add `.catch` handler to `worker.recognize` to handle OCR failures
- Reset UI and disable output area on errors
- Log errors and terminate the worker to free resources

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b729f37ee483309c9225e938c84bed