### PR TITLE
refactor: remove unnecessary tab permissions

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -30,36 +30,32 @@ document.addEventListener('DOMContentLoaded', function() {
       reader.onload =  function(event) {
         state.imgData = event.target.result;
 
-        chrome.tabs.query({ currentWindow: true, active: true }, (tabs) => {
-          // const activeTab = tabs[0];
-
-          const { TesseractWorker } = Tesseract;
-          const worker = new TesseractWorker({
-            workerPath: chrome.runtime.getURL('js/worker.min.js'),
-            langPath: chrome.runtime.getURL('traineddata'),
-            corePath: chrome.runtime.getURL('js/tesseract-core.wasm.js'),
-          });
-          worker.recognize(state.imgData)
-            .then(({ data }) => {
-              let segmentedText = segmentLines(data);
-              if (!spellToggle || spellToggle.checked) {
-                segmentedText = correctText(segmentedText);
-              }
-                outputArea.value = segmentedText;
-                scanMessage.innerText = "Completed!";
-                scanArea.classList.remove('processing');
-            })
-            .catch((err) => {
-              console.error(err);
-              scanArea.classList.remove('processing');
-              scanMessage.innerText = 'Failed to process image.';
-              outputArea.value = '';
-              outputArea.setAttribute('disabled', 'true');
-              if (worker.terminate) {
-                worker.terminate();
-              }
-            });
+        const { TesseractWorker } = Tesseract;
+        const worker = new TesseractWorker({
+          workerPath: chrome.runtime.getURL('js/worker.min.js'),
+          langPath: chrome.runtime.getURL('traineddata'),
+          corePath: chrome.runtime.getURL('js/tesseract-core.wasm.js'),
         });
+        worker.recognize(state.imgData)
+          .then(({ data }) => {
+            let segmentedText = segmentLines(data);
+            if (!spellToggle || spellToggle.checked) {
+              segmentedText = correctText(segmentedText);
+            }
+            outputArea.value = segmentedText;
+            scanMessage.innerText = "Completed!";
+            scanArea.classList.remove('processing');
+          })
+          .catch((err) => {
+            console.error(err);
+            scanArea.classList.remove('processing');
+            scanMessage.innerText = 'Failed to process image.';
+            outputArea.value = '';
+            outputArea.setAttribute('disabled', 'true');
+            if (worker.terminate) {
+              worker.terminate();
+            }
+          });
       };
       reader.readAsDataURL(imgBlob);
     }

--- a/manifest.json
+++ b/manifest.json
@@ -19,10 +19,7 @@
     "matches": ["<all_urls>"]
   }],
 
-  "permissions": [
-   "activeTab",
-   "tabs"
-   ],
+  "permissions": [],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; worker-src 'self'; connect-src 'self' https://localhost http://localhost http://127.0.0.1 ws://localhost ws://127.0.0.1 ws://localhost:3000; object-src 'self'"
   }


### PR DESCRIPTION
## Summary
- avoid querying active tab when processing pasted images
- drop `activeTab` and `tabs` permissions from manifest

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7321694a483308e45a933872fb886