### PR TITLE
Expand extension CSP for WASM and local connections

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,6 @@
 
   "permissions": [],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; worker-src 'self'; connect-src 'self' https://localhost http://localhost http://127.0.0.1 ws://localhost ws://127.0.0.1 ws://localhost:3000; object-src 'self'"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; connect-src 'self' data: https://localhost http://localhost http://127.0.0.1 ws://localhost ws://127.0.0.1 ws://localhost:3000; object-src 'self';"
   }
 }


### PR DESCRIPTION
## Summary
- allow WASM eval in extension scripts
- permit blob workers
- enable data and local endpoints for `connect-src`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b73b77a2a083309e1a7119b26caf29