### PR TITLE
Add wrapper for Tesseract worker path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ npm test
 ```
 
 The project uses **jest** for its tests.
+
+## Updating Tesseract.js
+
+The files `js/tesseract.min.js`, `js/worker.min.js`, and `js/tesseract-core.wasm.js` are vendored
+from the official [Tesseract.js](https://github.com/naptha/tesseract.js) releases. When upgrading,
+download fresh copies from upstream rather than editing the minified output directly. Any local
+customisation, such as the worker and core paths required for the Chrome extension, should be done
+via wrapper scripts like `js/tesseract-wrapper.js` instead of modifying the vendor files.

--- a/js/popup.js
+++ b/js/popup.js
@@ -24,11 +24,9 @@ document.addEventListener('DOMContentLoaded', function() {
     
     if (imgBlob !== null) {
       const { TesseractWorker } = Tesseract;
-      const worker = new TesseractWorker({
-        workerPath: chrome.runtime.getURL('js/worker.min.js'),
-        langPath: chrome.runtime.getURL('traineddata'),
-        corePath: chrome.runtime.getURL('js/tesseract-core.wasm.js'),
-      });
+        const worker = new TesseractWorker({
+          langPath: chrome.runtime.getURL('traineddata'),
+        });
       worker.recognize(imgBlob)
         .then(({ data }) => {
           let segmentedText = segmentLines(data);

--- a/js/tesseract-wrapper.js
+++ b/js/tesseract-wrapper.js
@@ -1,0 +1,28 @@
+(function () {
+  if (!window.Tesseract) {
+    return;
+  }
+
+  // Wrap createWorker to force workerPath/corePath under Chrome extension CSP
+  if (typeof window.Tesseract.createWorker === 'function') {
+    const origCreateWorker = window.Tesseract.createWorker.bind(window.Tesseract);
+    window.Tesseract.createWorker = function (options = {}) {
+      return origCreateWorker(Object.assign({
+        workerPath: chrome.runtime.getURL('js/worker.min.js'),
+        corePath: chrome.runtime.getURL('js/tesseract-core.wasm.js'),
+      }, options));
+    };
+  }
+
+  // Wrap legacy TesseractWorker constructor if present
+  if (typeof window.Tesseract.TesseractWorker === 'function') {
+    const OriginalWorker = window.Tesseract.TesseractWorker;
+    window.Tesseract.TesseractWorker = function (options = {}) {
+      return new OriginalWorker(Object.assign({
+        workerPath: chrome.runtime.getURL('js/worker.min.js'),
+        corePath: chrome.runtime.getURL('js/tesseract-core.wasm.js'),
+      }, options));
+    };
+    window.Tesseract.TesseractWorker.prototype = OriginalWorker.prototype;
+  }
+})();

--- a/popup.html
+++ b/popup.html
@@ -4,6 +4,7 @@
   <!-- Custom CSS -->
   <link rel="stylesheet" href="./css/main.css">
   <script src="./js/tesseract.min.js"></script>
+  <script src="./js/tesseract-wrapper.js"></script>
   <title>Snipper</title>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Wrap Tesseract API to spawn workers via `chrome.runtime.getURL` instead of editing minified vendor files
- Load new wrapper in popup and simplify worker construction
- Document how to update Tesseract assets and ignore `node_modules`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7793684b883308acdd85d79380215