### PR TITLE
Implement background OCR worker and messaging

### DIFF
--- a/js/background-ocr.js
+++ b/js/background-ocr.js
@@ -1,0 +1,28 @@
+importScripts('js/tesseract.min.js');
+
+const worker = Tesseract.createWorker({
+  workerPath: chrome.runtime.getURL('js/worker.min.js'),
+  corePath: chrome.runtime.getURL('js/tesseract-core.wasm.js'),
+  langPath: chrome.runtime.getURL('traineddata'),
+});
+
+let initialized = false;
+async function ensureInitialized() {
+  if (!initialized) {
+    await worker.load();
+    await worker.loadLanguage('eng');
+    await worker.initialize('eng');
+    initialized = true;
+  }
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === 'recognize' && message.image) {
+    (async () => {
+      await ensureInitialized();
+      const { data } = await worker.recognize(message.image);
+      sendResponse({ data });
+    })();
+    return true; // keep messaging channel open for async response
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,10 @@
     "default_popup": "popup.html"
   },
 
+  "background": {
+    "service_worker": "js/background-ocr.js"
+  },
+
   "web_accessible_resources": [{
     "resources": [
       "js/worker.min.js",
@@ -19,7 +23,7 @@
     "matches": ["<all_urls>"]
   }],
 
-  "permissions": [],
+  "permissions": ["scripting"],
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; worker-src 'self'; connect-src 'self'; object-src 'self';"
   }


### PR DESCRIPTION
## Summary
- add Tesseract-based background service worker for OCR
- send images from popup to service worker for text recognition
- register background worker and scripting permission in manifest

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7b1baf2f483309a01fda76810a4a6